### PR TITLE
feature: add jump_to_history_directory action

### DIFF
--- a/doc/vfiler.md
+++ b/doc/vfiler.md
@@ -597,6 +597,9 @@ Jump to root directory.
 #### jump_to_directory
 Jump to specified directory.
 
+#### jump_to_history_directory
+Jump to specified history directory.
+
 ---
 
 ### Action to select

--- a/lua/vfiler/actions/directory.lua
+++ b/lua/vfiler/actions/directory.lua
@@ -48,6 +48,23 @@ function M.jump_to_directory(vfiler, context, view)
   api.cd(vfiler, context, view, dirpath)
 end
 
+function M.jump_to_history_directory(vfiler, context, view)
+  local history = context:directory_history()
+  if #history == 0 then
+    return
+  end
+
+  local Menu = require('vfiler/extensions/menu')
+  local menu = Menu.new(vfiler, 'Select History Directory', {
+    initial_items = history,
+
+    on_selected = function(filer, ctx, v, path)
+      api.cd(filer, ctx, v, path)
+    end,
+  })
+  api.start_extension(vfiler, context, view, menu)
+end
+
 function M.jump_to_home(vfiler, context, view)
   local dirpath = vim.fn.expand('~')
   api.cd(vfiler, context, view, dirpath)


### PR DESCRIPTION
I request the feature to jump one from directories visited so far.
This PR adds `jump_to_history_directory` action.

- Add a `History` object into `Session` object.
- `History` object retain visited paths by a ring buffer.
- `jump_to_history_directory` shows the history by using `Menu` extension.

I'm sorry, but I don't have a Windows machine, so I can only check the function on Mac and Debian.