### PR TITLE
fix: update opened directory stat

### DIFF
--- a/lua/vfiler/context.lua
+++ b/lua/vfiler/context.lua
@@ -335,7 +335,7 @@ function Context:reload()
   for dir in walk_directories(self.root) do
     if dir.opened then
       if vim.fn.getftime(dir.path) > dir.time then
-        dir:update_stat()
+        dir:update()
         dir:open()
       end
     end

--- a/lua/vfiler/context.lua
+++ b/lua/vfiler/context.lua
@@ -335,6 +335,7 @@ function Context:reload()
   for dir in walk_directories(self.root) do
     if dir.opened then
       if vim.fn.getftime(dir.path) > dir.time then
+        dir:update_stat()
         dir:open()
       end
     end

--- a/lua/vfiler/items/directory.lua
+++ b/lua/vfiler/items/directory.lua
@@ -98,6 +98,16 @@ function Directory:open(recursive)
   self.opened = true
 end
 
+function Directory:update_stat()
+  local stat = fs.stat(self.path)
+  if not stat then
+    return
+  end
+  self.size = stat.size
+  self.time = stat.time
+  self.mode = stat.mode
+end
+
 function Directory:_add(item)
   item.parent = self
   item.level = self.level + 1

--- a/lua/vfiler/items/directory.lua
+++ b/lua/vfiler/items/directory.lua
@@ -98,7 +98,7 @@ function Directory:open(recursive)
   self.opened = true
 end
 
-function Directory:update_stat()
+function Directory:update()
   local stat = fs.stat(self.path)
   if not stat then
     return


### PR DESCRIPTION
This PR fix the bellow issue.
- When file modifitication (e.g. new_file action) happens in a opened directory tree, the directory stat display (e.g. timestamp) is not updated.
- In the same case, nested opened directories in the directory are closed even after second and subsequent reloads
