### PR TITLE
update: make extension sort stable

### DIFF
--- a/lua/vfiler/sort.lua
+++ b/lua/vfiler/sort.lua
@@ -86,7 +86,7 @@ M.set('extension', function(item1, item2)
 
   local ext1 = vim.fn.fnamemodify(item1.name, ':e')
   local ext2 = vim.fn.fnamemodify(item2.name, ':e')
-  if #ext1 == 0 and #ext2 == 0 then
+  if (#ext1 == 0 and #ext2 == 0) or (ext1:lower() == ext2:lower()) then
     return M.compare_string(item1.name, item2.name)
   end
   return M.compare_string(ext1, ext2)


### PR DESCRIPTION
By extension sort, the order amoung same extension files is changed whenever reload action in my environment.
So, this PR compares the names for same extension files.