### PR TITLE
fix: exclude root from target by toggle_select_all

### DIFF
--- a/lua/vfiler/actions/select.lua
+++ b/lua/vfiler/actions/select.lua
@@ -18,7 +18,9 @@ end
 
 function M.toggle_select_all(vfiler, context, view)
   for item in view:walk_items() do
-    item.selected = not item.selected
+    if item ~= context.root then
+      item.selected = not item.selected
+    end
   end
   view:redraw()
 end

--- a/tests/vfiler/actions/select_spec.lua
+++ b/tests/vfiler/actions/select_spec.lua
@@ -24,7 +24,9 @@ describe('select actions', function()
     it(u.vfiler.desc('toggle_select_all', vfiler), function()
       vfiler:do_action(a.toggle_select_all)
       for item in vfiler._view:walk_items() do
-        assert.is_true(item.selected)
+        if item ~= vfiler._context.root then
+          assert.is_true(item.selected)
+        end
       end
     end)
   end)


### PR DESCRIPTION
Currently, toggle_select_all action selects also root path.
I don't think this behaviour is intentional because root appearance is not changed, then I fixed.
