### PR TITLE
aupdate: normalize consecutive slashes

### DIFF
--- a/lua/vfiler/libs/core.lua
+++ b/lua/vfiler/libs/core.lua
@@ -213,7 +213,7 @@ function M.path.normalize(path)
   if path == '/' then
     return '/'
   end
-  return M.path.escape(vim.fn.fnamemodify(path, ':p'))
+  return M.path.escape(vim.fn.fnamemodify(path, ':p')):gsub('/+', '/')
 end
 
 function M.path.parent(path)


### PR DESCRIPTION
# Issue
If a path including consecutive slashes such as `/path//to//dir` is input for `jump_to_directory` action, the path is registered in history as it is.
After that, visiting the path by other actions, the path with single slash is also registered in history.
As result, same paths are registered in history.

# Fix
This PR replace consecutive slashes with single slashes in normalize function.
