### PR TITLE
feature: enable to rename in copy and move

### DIFF
--- a/lua/vfiler/libs/cmdline.lua
+++ b/lua/vfiler/libs/cmdline.lua
@@ -7,6 +7,7 @@ M.choice = {
   YES = '&Yes',
   NO = '&No',
   CANCEL = '&Cancel',
+  RENAME = '&Rename',
 }
 
 function M.clear_prompt()
@@ -82,6 +83,14 @@ function M.util.confirm_overwrite(name)
   return M.confirm(
     ('"%s" already exists. Overwrite?'):format(name),
     { M.choice.YES, M.choice.NO },
+    1
+  )
+end
+
+function M.util.confirm_overwrite_or_rename(name)
+  return M.confirm(
+    ('"%s" already exists. Overwrite?'):format(name),
+    { M.choice.YES, M.choice.NO, M.choice.RENAME },
     1
   )
 end


### PR DESCRIPTION
# Feature
This PR enables copy and move actions to rename the targets when the names of targets already existed.
I sometimes copy a file into the same directory. Then rename is happy for me.