### PR TITLE
Fix git status parse error for large git status output

### DIFF
--- a/lua/vfiler/libs/async/jobs/job_nvim.lua
+++ b/lua/vfiler/libs/async/jobs/job_nvim.lua
@@ -24,9 +24,19 @@ function Job:start(command, options)
       end
     end,
   }
+  local data_buffer = ''
   if options.on_received then
     jobopts.on_stdout = function(channel, datas, name)
-      for _, data in ipairs(datas) do
+      datas[1] = data_buffer .. datas[1]
+      local data_len = #datas
+      if datas[data_len] ~= '' then
+        data_buffer = datas[data_len]
+        data_len = data_len - 1
+      else
+        data_buffer = ''
+      end
+      for i = 1, data_len do
+        local data = datas[i]
         if #data > 0 then
           options.on_received(self, data)
         end
@@ -35,6 +45,9 @@ function Job:start(command, options)
   end
   if options.on_completed then
     jobopts.on_exit = function(id, code, event)
+      if options.on_received and data_buffer ~= '' then
+        options.on_received(self, data_buffer)
+      end
       options.on_completed(self, code)
     end
   end

--- a/lua/vfiler/libs/git.lua
+++ b/lua/vfiler/libs/git.lua
@@ -39,7 +39,7 @@ local function parse_git_status(rootpath, result)
   local splitted = vim.list.from(vim.fn.split(rpath, ' -> '))
   rpath = splitted[#splitted]
   -- Removing: extra characters
-  rpath = rpath:gsub('^"', ''):gsub('^"', '')
+  rpath = rpath:gsub('^"', ''):gsub('"$', '')
   return core.path.join(rootpath, rpath),
     { us = status:sub(1, 1), them = status:sub(2, 2) }
 end


### PR DESCRIPTION
# Issue

As bellow, nvim job_control may pass partial line. So if a output of git status has too many lines, it is possible to happen errors in git status parse.

http://neovim.io/doc/user/job_control.html
>  Note 2:
>	 Job event handlers may receive partial (incomplete) lines. For a given
>	 invocation of on_stdout/on_stderr, a:data is not guaranteed to end
>	 with a newline.

This PR joins potentially partial lines.
This PR also fix to display git status for paths surrounded by double quote.