### PR TITLE
change: set default path to jump_to_directory action

### DIFF
--- a/lua/vfiler/actions/directory.lua
+++ b/lua/vfiler/actions/directory.lua
@@ -36,7 +36,7 @@ function M.change_to_parent(vfiler, context, view)
 end
 
 function M.jump_to_directory(vfiler, context, view)
-  local dirpath = cmdline.input('Jump to?', '', 'dir')
+  local dirpath = cmdline.input('Jump to?', context.root.path, 'dir')
   if #dirpath == 0 then
     return
   end


### PR DESCRIPTION
I suggest to set current directory path as default path to jump_to_directory action.

This will ease to jump to a parent or ancestor directory with less keys.
Also, this will ease to select a path bellow current directory by history suggestion.

This PR is suggestion, so I never mind not to be accepted.