### PR TITLE
fix: view:get_item when opening two buffers

### DIFF
--- a/lua/vfiler/view.lua
+++ b/lua/vfiler/view.lua
@@ -220,7 +220,7 @@ function View:get_item(lnum)
   if not self._items then
     return nil
   end
-  lnum = lnum or vim.fn.line('.')
+  lnum = lnum or vim.fn.line('.', self:winid())
   return self._items.list[lnum]
 end
 


### PR DESCRIPTION
# Issue

When two VFiler buffer is opened by `switch_to_filer` action, `view:get_item` of either buffer may return wrong item or nil.
(`view:get_item` of non-active buffer will be called when switching to terminal window running nvim).

Sometimes this causes error.

Then, this PR fix that `view:get_item` returns a correct item.