### PR TITLE
change: prefer minwidth / minheigth to window size

### DIFF
--- a/lua/vfiler/libs/core.lua
+++ b/lua/vfiler/libs/core.lua
@@ -539,7 +539,7 @@ M.math = {}
 
 -- Within the max and min between
 function M.math.within(v, min, max)
-  return math.min(math.max(v, min), max)
+  return math.max(math.min(v, max), min)
 end
 
 --- Returns "integer" if the argument is an integer,

--- a/tests/vfiler/libs/core_spec.lua
+++ b/tests/vfiler/libs/core_spec.lua
@@ -272,6 +272,8 @@ describe('core.math', function()
       { v = 10, min = 5, max = 20, expected = 10 },
       { v = 4, min = 5, max = 20, expected = 5 },
       { v = 21, min = 5, max = 20, expected = 20 },
+      { v = 10, min = 20, max = 5, expected = 20 },
+      { v = 21, min = 20, max = 5, expected = 20 },
       { v = -4, min = -5, max = 20, expected = -4 },
       { v = -6, min = -5, max = 20, expected = -5 },
       { v = -6, min = -8, max = -5, expected = -6 },


### PR DESCRIPTION
# Suggestion

Currently, menu or bookmark floating window size is limitted to the parent window size even if minwidth / minheight is specified by configuration such bellow.

```lua
    require("vfiler/extensions/menu/config").setup({
        options = {
            floating = {
                minwidth = 100,
            }
        },
   })
```

By this limitation, the floating window tends to be too narrow on explorer style.
So I want to prefer minwidth / minheigth to the parent window size.
