### PR TITLE
fix: delete symlink itself instead of referenced directory

### DIFF
--- a/lua/vfiler/items/item.lua
+++ b/lua/vfiler/items/item.lua
@@ -15,7 +15,11 @@ function Item.new(stat)
 end
 
 function Item:delete()
-  if not fs.delete(self.path) then
+  local path = self.path
+  if self.link and self.type == 'directory' and path:match('/$') then
+    path = path:sub(1, #path - 1)
+  end
+  if not fs.delete(path) then
     core.message.error('"%s" Cannot delete.', self.name)
     return false
   end


### PR DESCRIPTION
# Issue

`delete` action for a symbolic link referenceing directory deletes the directory instead of the link itself.

# Cause

The path used by `delete` action has '/' suffix, then the target is not the symbolic link itself.

# Change

Remove '/' suffix from the path when deleting a symbolic link referencing directory.