### PR TITLE
change: retain tree state even after file update

### DIFF
--- a/lua/vfiler/items/directory.lua
+++ b/lua/vfiler/items/directory.lua
@@ -132,7 +132,7 @@ function Directory:_open(recursive, child_directories)
       if item.type == 'directory' then
         local old_dir_item = child_directories[item.name]
         if recursive or (old_dir_item and old_dir_item.opened) then
-          table.insert(children, {item, old_dir_item})
+          table.insert(children, { item, old_dir_item })
         end
       end
     end

--- a/lua/vfiler/items/item.lua
+++ b/lua/vfiler/items/item.lua
@@ -48,13 +48,7 @@ function Item:_become_orphan()
     return
   end
 
-  local children = self.parent.children
-  for i, child in ipairs(children) do
-    if child.path == self.path then
-      table.remove(children, i)
-      break
-    end
-  end
+  self.parent:remove(self)
 end
 
 function Item:_move(destpath)


### PR DESCRIPTION
# Issue

When create or update a file, the tree of directories near the file is closed.

# Change

Check the previous opened state for each directory entry when parent directory is reopened.

before:
![before](https://github.com/obaland/vfiler.vim/assets/1457023/88c5d621-2afc-4eaf-aaf2-ae4b2eb72a85)

after:
![after](https://github.com/obaland/vfiler.vim/assets/1457023/3880c2fa-8680-49b4-901c-6d093786095d)
