### PR TITLE
feat: add action to reload all directories

### DIFF
--- a/doc/vfiler.md
+++ b/doc/vfiler.md
@@ -728,6 +728,11 @@ Switches to other drive(Windows) or mount point(Mac/Linux).
 #### reload
 Reload the `vfiler.vim` buffer.
 
+#### reload_all_dir
+Reload the `vfiler.vim` buffer.<br>
+The difference between `reload` and `reload_all_dir`is the former reload only the items in directories that have been updated,<br>
+while the latter reload also the items in all directories.
+
 #### quit
 Quit the `vfiler.vim` buffer.
 

--- a/lua/vfiler/actions/buffer.lua
+++ b/lua/vfiler/actions/buffer.lua
@@ -10,6 +10,12 @@ local M = {}
 -- Control buffer
 ------------------------------------------------------------------------------
 
+local function reload(context, view, reload_all_dir)
+  context:save(view:get_item().path)
+  context:reload(reload_all_dir)
+  view:draw(context)
+end
+
 function M.quit(vfiler, context, view)
   if context.options.quit then
     utils.close_preview(vfiler, context, view)
@@ -27,13 +33,19 @@ function M.redraw(vfiler, context, view)
 end
 
 function M.reload(vfiler, context, view)
-  context:save(view:get_item().path)
-  context:reload()
-  view:draw(context)
+  reload(context, view, false)
 end
 
 function M.reload_all(vfiler, context, view)
   VFiler.foreach(M.reload)
+end
+
+function M.reload_all_dir(vfiler, context, view)
+  reload(context, view, true)
+end
+
+function M.reload_all_dir_all(vfiler, context, view)
+  VFiler.foreach(M.reload_all_dir)
 end
 
 function M.switch_to_filer(vfiler, context, view)

--- a/lua/vfiler/context.lua
+++ b/lua/vfiler/context.lua
@@ -266,9 +266,10 @@ function Context:perform_auto_cd()
 end
 
 -- Reload the current directory path
-function Context:reload()
+---@param reload_all_dir boolean
+function Context:reload(reload_all_dir)
   local root_path = self.root.path
-  if vim.fn.getftime(root_path) > self.root.time then
+  if reload_all_dir or vim.fn.getftime(root_path) > self.root.time then
     self:switch(root_path)
     return
   end


### PR DESCRIPTION
# Issue

Currently, `reload` action updates only the items in directories that have been updated. Therefore, in the case updating item without updating directory (e.g. a item already exisiting is modified), the information for the item is never reload.

# Change

This PR adds `reload_all_dir` action, which update the all directories including current root.