### PR TITLE
feat: allow items in different directories to be renamed with same name

### DIFF
--- a/lua/vfiler/extensions/rename.lua
+++ b/lua/vfiler/extensions/rename.lua
@@ -46,17 +46,20 @@ function Rename:check()
       core.message.error('Blank line. (%d)', lnum)
       return false
     end
+
+    local item = self:get_item(lnum)
+    local dirpath = item.parent.path
+    local path = core.path.join(dirpath, line)
+
     -- Check for duplicate lines
     for i = lnum + 1, #lines do
-      if line == lines[i] then
+      local other_item = self:get_item(i)
+      if path == core.path.join(other_item.parent.path, lines[i]) then
         core.message.error('Duplicated names. (line: %d and %d)', lnum, i)
         return false
       end
     end
     -- Check for duplicate path
-    local item = self:get_item(lnum)
-    local dirpath = item.parent.path
-    local path = core.path.join(dirpath, line)
     local exists = false
     if line ~= item.name then
       if item.type == 'directory' then


### PR DESCRIPTION
# Issue

Currently, rename for multiple items disallows to specify same name even if the items are in different directories.

# Change

This PR will allow the items in different directories to be renamed with same name.