### PR TITLE
feat: add read_preview_file hook

### DIFF
--- a/doc/vfiler.md
+++ b/doc/vfiler.md
@@ -784,6 +784,35 @@ require('vfiler/action').setup {
 }
 ```
 
+#### hook.read_preview_file
+Sets the function to be hooked when reading a preview file.</br>
+This hook function is used to customize preview contents.</br>
+This function shall return lines of preview content and the content filetype.</br>
+If the returned filetype is `nil`, actual filetype is detected from the content.
+
+- Type: `function`
+
+##### Example
+
+```lua
+require('vfiler/action').setup {
+  hook = {
+    -- Read contents for specific preview file.
+    read_preview_file = function(path, default_read_func)
+      local ext = vim.fn.fnamemodify(path, ":e")
+      if ext == 'zip' and vim.fn.executable('unzip') then
+        -- For zip files, show archived path list
+        local lines = vim.fn.systemlist('unzip -l ' .. vim.fn.shellescape(path))
+        return lines, 'text'
+      else
+        -- For other files, show contents as is
+        return default_read_func(path)
+      end
+    end,
+  }
+}
+```
+
 # About
 
 `vfiler.vim` is developed by obaland and licensed under the MIT License.<br>

--- a/lua/vfiler/actions/config.lua
+++ b/lua/vfiler/actions/config.lua
@@ -8,6 +8,9 @@ M.configs = {
     filter_choose_window = function(winids)
       return winids
     end,
+    read_preview_file = function(path, default_read_func)
+      return default_read_func(path)
+    end,
   },
 }
 

--- a/lua/vfiler/actions/utilities.lua
+++ b/lua/vfiler/actions/utilities.lua
@@ -193,7 +193,13 @@ function M.open_preview(vfiler, context, view)
   if item.type == 'directory' then
     preview:close()
   else
-    preview:open(item.path)
+    local hook = config.configs.hook.read_preview_file
+    if type(hook) ~= 'function' then
+      hook = function(path, read_func)
+        return read_func(path)
+      end
+    end
+    preview:open(item.path, hook)
   end
   return true
 end


### PR DESCRIPTION
# Suggestion

This PR adds a new hook to customize file contents for preview.

# Motivation

Currently, preview action shows the content of a specific file as is.
This behaviour is desirable for text files, but not for binary files.

For binary files, it is usefull to be enable to show text data related to the file (e.g. audio duration, exif, archived path list, etc).

So, this PR adds a hook which receives a file path and returns the display content.

