### PR TITLE
feat: suppress unnecessary auto scrolling

### DIFF
--- a/lua/vfiler/view.lua
+++ b/lua/vfiler/view.lua
@@ -307,10 +307,13 @@ end
 function View:move_cursor(path)
   local lnum = self:indexof(path)
   -- Skip header line
-  core.cursor.move(math.max(lnum, self:top_lnum()))
-  -- Correspondence to show the header line
-  -- when moving to the beginning of the line.
-  vim.fn.execute('normal zb', 'silent')
+  local line = math.max(lnum, self:top_lnum())
+  core.cursor.move(line)
+  if self._header and line == 2 then
+    -- Correspondence to show the header line
+    -- when moving to the beginning of the line.
+    vim.fn.execute('normal! zb', 'silent')
+  end
 end
 
 --- Get the number of line in the view buffer


### PR DESCRIPTION
This PR will suppress the unnecessary scrolling automatically by closing tree, sorting, creating items, or rename.
Although this scrolling is for showing the header line, currently the scrolling will happens even in the situation not to be unable to show the header.

Because this scrolling is happened whenever closing a tree, I am forced to scroll manually in order to show the items bellow the closed item.
Therefore, this PR makes that the scrolling will be happened only when showing the top line.