### PR TITLE
fix: find_file for path including hyphens

### DIFF
--- a/lua/vfiler/context/init.lua
+++ b/lua/vfiler/context/init.lua
@@ -52,7 +52,7 @@ end
 ---@param path string
 function Context:open_tree(path)
   path = core.path.normalize(path)
-  local s, e = path:find(self.root.path)
+  local s, e = path:find(self.root.path, 1, true)
   if not s then
     return nil
   end


### PR DESCRIPTION
# Issue

`find_file` option does not work for a path including hyphen, because the hyphen is treat as a lua pattern by `string.find`.

# Change

Add `string find` third argument which indicates the first argument is plain but not pattern.