### PR TITLE
fix: avoid treating item name as a pattern in rename_files

### DIFF
--- a/lua/vfiler/extensions/rename.lua
+++ b/lua/vfiler/extensions/rename.lua
@@ -111,7 +111,7 @@ function Rename:_on_opened(winid, bufnr, items, configs)
   }
   -- Create "NotChanged" syntax for each line
   for i, item in ipairs(items) do
-    local pattern = ([[^\%%%dl%s$]]):format(i, item.name)
+    local pattern = ([[^\%%%dl\V%s\$]]):format(i, item.name)
     table.insert(
       syntaxes,
       core.syntax.create(group_notchanged, {


### PR DESCRIPTION
# Issue

In `rename_files`, if the item's name includes `[` and `]`, the name is treated as a regex pattern.
As a result, may fail to open rename window (e.g. the name is `[test-1]`, which is invalid regex pattern).

# Change

Avoid treating the names as a pattern, by adding very nomagic flag.