### PR TITLE
fix: escape quote in echo message

### DIFF
--- a/lua/vfiler/libs/core.lua
+++ b/lua/vfiler/libs/core.lua
@@ -134,24 +134,37 @@ end
 ------------------------------------------------------------------------------
 M.message = {}
 
+---@param msg string
+---@return string
+local function escape_quote(msg)
+  local result, _ = msg:gsub([[']], [['']])
+  return result
+end
+
 ---print error message
 function M.message.error(format, ...)
   local msg = format:format(...)
   vim.command(
-    ([[echohl ErrorMsg | echomsg '[vfiler]: %s' | echohl None]]):format(msg)
+    ([[echohl ErrorMsg | echomsg '[vfiler]: %s' | echohl None]]):format(
+      escape_quote(msg)
+    )
   )
 end
 
 ---print information message
 function M.message.info(format, ...)
-  vim.command(([[echo '[vfiler]: %s']]):format(format:format(...)))
+  vim.command(
+    ([[echo '[vfiler]: %s']]):format(escape_quote(format:format(...)))
+  )
 end
 
 ---print warning message
 function M.message.warning(format, ...)
   local msg = format:format(...)
   vim.command(
-    ([[echohl WarningMsg | echomsg '[vfiler]: %s' | echohl None]]):format(msg)
+    ([[echohl WarningMsg | echomsg '[vfiler]: %s' | echohl None]]):format(
+      escape_quote(msg)
+    )
   )
 end
 
@@ -159,7 +172,9 @@ end
 function M.message.question(format, ...)
   local msg = format:format(...)
   vim.command(
-    ([[echohl Question | echo '[vfiler]: %s' | echohl None]]):format(msg)
+    ([[echohl Question | echo '[vfiler]: %s' | echohl None]]):format(
+      escape_quote(msg)
+    )
   )
 end
 


### PR DESCRIPTION
# Issue

If a message for echo functions includes single quotes, the functions will emit an error.
This is happens if operations for a file which name includes quotes are invoked.

# Changes

Escape the single quotes.

