### PR TITLE
feat: support socket and fifo files

### DIFF
--- a/lua/vfiler/actions/utilities.lua
+++ b/lua/vfiler/actions/utilities.lua
@@ -193,7 +193,7 @@ function M.open_preview(vfiler, context, view)
 
   preview.line = vim.fn.line('.')
   local item = view:get_item(preview.line)
-  if item.type == 'directory' then
+  if item.type ~= 'file' then
     preview:close()
   else
     local hook = config.configs.hook.read_preview_file

--- a/lua/vfiler/columns/name.lua
+++ b/lua/vfiler/columns/name.lua
@@ -52,6 +52,24 @@ function NameColumn.new()
       },
       highlight = 'vfilerHidden',
     },
+    {
+      group = 'vfilerName_Socket',
+      name = 'socket',
+      region = {
+        start_mark = 'n.=</',
+        end_mark = end_mark,
+      },
+      highlight = 'vfilerSocket',
+    },
+    {
+      group = 'vfilerName_Fifo',
+      name = 'fifo',
+      region = {
+        start_mark = 'n.|</',
+        end_mark = end_mark,
+      },
+      highlight = 'vfilerFifo',
+    },
   })
   self.variable = true
   self.stretch = true

--- a/lua/vfiler/items/directory.lua
+++ b/lua/vfiler/items/directory.lua
@@ -9,7 +9,12 @@ local function new_item(stat)
   local item
   if stat.type == 'directory' then
     item = Directory.new(stat)
-  elseif stat.type == 'file' or stat.type == 'link' then
+  elseif
+    stat.type == 'file'
+    or stat.type == 'link'
+    or stat.type == 'fifo'
+    or stat.type == 'socket'
+  then
     item = File.new(stat)
   else
     core.message.warning('Unknown "%s" file type. (%s)', stat.type, stat.path)

--- a/plugin/vfiler.vim
+++ b/plugin/vfiler.vim
@@ -27,6 +27,8 @@ highlight default link vfilerFile              None
 highlight default link vfilerHeader            Statement
 highlight default link vfilerHidden            Comment
 highlight default link vfilerLink              Constant
+highlight default link vfilerFifo              Debug
+highlight default link vfilerSocket            Error
 highlight default link vfilerSelected          Title
 highlight default link vfilerSize              Statement
 highlight default link vfilerTime              None


### PR DESCRIPTION
# Issue

Currently, when opening a directory including socket or fifo files (e.g. `docker.sock`), vfiler emits error messages.

# Changes

Treat socket and fifo as a reguler file.
But these types are excluded for preview targets because preview is blocked forever if including these types.