### PR TITLE
fix: prevent window option inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - windows-latest
         version:
           - stable
-          - v0.5.0
+          - v0.8.0
     steps:
       - uses: actions/checkout@v4
       - uses: rhysd/action-setup-vim@v1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Requirements
 
-vfiler.vim requires Neovim(0.5.0+) or Vim8.2+ with [if\_lua](https://vimhelp.org/if_lua.txt.html#if_lua.txt).
+vfiler.vim requires Neovim(0.8.0+) or Vim8.2+ with [if\_lua](https://vimhelp.org/if_lua.txt.html#if_lua.txt).
 
 ## Installation
 

--- a/lua/vfiler/windows/floating.lua
+++ b/lua/vfiler/windows/floating.lua
@@ -51,15 +51,31 @@ function Floating:set_title(title)
     local winid = api.nvim_open_win(buffer.number, false, config)
 
     -- set options
-    api.nvim_win_set_option(
-      winid,
+    api.nvim_set_option_value(
       'winhighlight',
-      'Normal:vfilerFloatingWindowTitle'
+      'Normal:vfilerFloatingWindowTitle',
+      { scope = 'local', win = winid }
     )
-    api.nvim_win_set_option(winid, 'cursorline', false)
-    api.nvim_win_set_option(winid, 'number', false)
-    api.nvim_win_set_option(winid, 'relativenumber', false)
-    api.nvim_win_set_option(winid, 'signcolumn', 'no')
+    api.nvim_set_option_value(
+      'cursorline',
+      false,
+      { scope = 'local', win = winid }
+    )
+    api.nvim_set_option_value(
+      'number',
+      false,
+      { scope = 'local', win = winid }
+    )
+    api.nvim_set_option_value(
+      'relativenumber',
+      false,
+      { scope = 'local', win = winid }
+    )
+    api.nvim_set_option_value(
+      'signcolumn',
+      'no',
+      { scope = 'local', win = winid }
+    )
 
     -- set title name
     core.try({
@@ -107,7 +123,11 @@ function Floating:_on_open(buffer, config)
   self._config.noautocmd = true
   local enter = config.focusable ~= nil and config.focusable or true
   self._winid = api.nvim_open_win(buffer.number, enter, self._config)
-  api.nvim_win_set_option(self._winid, 'winhighlight', 'Normal:Normal')
+  api.nvim_set_option_value(
+    'winhighlight',
+    'Normal:Normal',
+    { scope = 'local', win = self._winid }
+  )
 
   local cmd = (':lua require("vfiler/windows/floating")._try_close(%d)'):format(
     self._winid
@@ -124,6 +144,11 @@ end
 function Floating:_on_update(winid, buffer, config)
   if buffer.number ~= api.nvim_win_get_buf(winid) then
     api.nvim_win_set_buf(winid, buffer.number)
+    api.nvim_set_option_value(
+      'winhighlight',
+      'Normal:Normal',
+      { scope = 'local', win = self._winid }
+    )
   end
   self._config = self:_to_win_config(config)
   api.nvim_win_set_config(winid, self._config)


### PR DESCRIPTION
# Issue

When opening a some floating window from a vfiler floating window, the window options that vfiler set to self window are inherited to the new opening window.
(e.g. winhighlight is also applied to the new floating window)

# Changes

Use `nvim_set_option_value` instead of `nvim_win_set_option` because this API supports local option.

# Note

However, `nvim_set_option_value` with scope argument is supported by Nvim 0.8.0 or higher.
Then this PR changes the Nvim version vfiler supports.